### PR TITLE
Adjust CI process

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  DOCKER_IMAGE: 'registry.gitlab.eox.at/esa/vires_vre_ops/vre-swarm-notebook:0.10.3'
+  DOCKER_IMAGE: 'registry.gitlab.eox.at/esa/vires_vre_ops/vre-swarm-notebook:0.10.5'
 
 jobs:
   pre-commit:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -2,12 +2,22 @@ on:
   pull_request:
     branches:
       - staging
+  workflow_dispatch:
 
 env:
   DOCKER_IMAGE: 'registry.gitlab.eox.at/esa/vires_vre_ops/vre-swarm-notebook:0.10.3'
 
 jobs:
-  run:
+  pre-commit:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.3
+      with:
+        extra_args: --hook-stage manual --all-files
+  book:
     name: Build Jupyter Book (Staging)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 
 env:
   DOCKER_IMAGE: 'registry.gitlab.eox.at/esa/vires_vre_ops/vre-swarm-notebook:0.10.3'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  DOCKER_IMAGE: 'registry.gitlab.eox.at/esa/vires_vre_ops/vre-swarm-notebook:0.10.3'
+  DOCKER_IMAGE: 'registry.gitlab.eox.at/esa/vires_vre_ops/vre-swarm-notebook:0.10.5'
 
 jobs:
   run:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,4 @@ repos:
     rev: 0.5.0
     hooks:
       - id: nbstripout
+        args: ["--extra-keys", "metadata.kernelspec metadata.language_info.version"]

--- a/dashboards/0000_concept_demo.ipynb
+++ b/dashboards/0000_concept_demo.ipynb
@@ -182,11 +182,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -196,8 +191,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/dashboards/00_Product-Availability.ipynb
+++ b/dashboards/00_Product-Availability.ipynb
@@ -358,11 +358,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -372,8 +367,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/dashboards/02_GVO-Geomagnetic-Virtual-Observatories.ipynb
+++ b/dashboards/02_GVO-Geomagnetic-Virtual-Observatories.ipynb
@@ -618,11 +618,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -632,8 +627,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/dashboards/04_Conjunctions.ipynb
+++ b/dashboards/04_Conjunctions.ipynb
@@ -295,11 +295,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -309,8 +304,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/01a__Intro-Jupyter-Python.ipynb
+++ b/notebooks/01a__Intro-Jupyter-Python.ipynb
@@ -863,11 +863,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -877,8 +872,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/01b1_Pandas-and-Plots.ipynb
+++ b/notebooks/01b1_Pandas-and-Plots.ipynb
@@ -552,11 +552,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -566,8 +561,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/02a__Intro-Swarm-viresclient.ipynb
+++ b/notebooks/02a__Intro-Swarm-viresclient.ipynb
@@ -316,11 +316,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -330,8 +325,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   },
   "toc-autonumbering": false
  },

--- a/notebooks/02b__viresclient-Available-Data.ipynb
+++ b/notebooks/02b__viresclient-Available-Data.ipynb
@@ -382,11 +382,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -396,8 +391,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   },
   "toc-showmarkdowntxt": false
  },

--- a/notebooks/02c__viresclient-API.ipynb
+++ b/notebooks/02c__viresclient-API.ipynb
@@ -3366,11 +3366,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -3380,8 +3375,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/02d__viresclient-Large-Data.ipynb
+++ b/notebooks/02d__viresclient-Large-Data.ipynb
@@ -307,11 +307,6 @@
   "execution": {
    "timeout": 1200
   },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -321,8 +316,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/02e1_Conjunction-Interface.ipynb
+++ b/notebooks/02e1_Conjunction-Interface.ipynb
@@ -200,11 +200,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -214,8 +209,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/02h1_HAPI.ipynb
+++ b/notebooks/02h1_HAPI.ipynb
@@ -124,11 +124,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -138,8 +133,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/02z1__Template-Basic.ipynb
+++ b/notebooks/02z1__Template-Basic.ipynb
@@ -164,11 +164,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -178,8 +173,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/03a1_Demo-MAGx_LR_1B.ipynb
+++ b/notebooks/03a1_Demo-MAGx_LR_1B.ipynb
@@ -444,11 +444,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -458,8 +453,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/03a2_Demo-MAGx_HR_1B.ipynb
+++ b/notebooks/03a2_Demo-MAGx_HR_1B.ipynb
@@ -167,11 +167,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -181,8 +176,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/03b__Demo-EFIx_LP_1B.ipynb
+++ b/notebooks/03b__Demo-EFIx_LP_1B.ipynb
@@ -180,11 +180,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -194,8 +189,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/03c__Demo-IPDxIRR_2F.ipynb
+++ b/notebooks/03c__Demo-IPDxIRR_2F.ipynb
@@ -207,11 +207,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -221,8 +216,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/03d__Demo-TECxTMS_2F.ipynb
+++ b/notebooks/03d__Demo-TECxTMS_2F.ipynb
@@ -164,11 +164,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -178,8 +173,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/03e1_Demo-FACxTMS_2F.ipynb
+++ b/notebooks/03e1_Demo-FACxTMS_2F.ipynb
@@ -299,11 +299,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -313,8 +308,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/03e2_Demo-FAC_TMS_2F.ipynb
+++ b/notebooks/03e2_Demo-FAC_TMS_2F.ipynb
@@ -507,11 +507,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -521,8 +516,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/03f__Demo-EEFxTMS_2F.ipynb
+++ b/notebooks/03f__Demo-EEFxTMS_2F.ipynb
@@ -182,11 +182,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -196,8 +191,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/03g__Demo-IBIxTMS_2F.ipynb
+++ b/notebooks/03g__Demo-IBIxTMS_2F.ipynb
@@ -131,11 +131,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -145,8 +140,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/03h1_Demo-AEBS-AEJxLPL.ipynb
+++ b/notebooks/03h1_Demo-AEBS-AEJxLPL.ipynb
@@ -609,11 +609,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -623,8 +618,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/03h2_Demo-AEBS-AEJxLPS.ipynb
+++ b/notebooks/03h2_Demo-AEBS-AEJxLPS.ipynb
@@ -442,11 +442,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -456,8 +451,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/03h3_Demo-AEBS-AOBxFAC.ipynb
+++ b/notebooks/03h3_Demo-AEBS-AOBxFAC.ipynb
@@ -244,11 +244,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -258,8 +253,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/03i1_Demo-VOBS.ipynb
+++ b/notebooks/03i1_Demo-VOBS.ipynb
@@ -613,11 +613,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -627,8 +622,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/03j1_Demo-PRISM-MITx.ipynb
+++ b/notebooks/03j1_Demo-PRISM-MITx.ipynb
@@ -236,11 +236,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -250,8 +245,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/03k1_Demo-EFIxTIE.ipynb
+++ b/notebooks/03k1_Demo-EFIxTIE.ipynb
@@ -283,8 +283,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/03k2_Demo-EFIxTCT.ipynb
+++ b/notebooks/03k2_Demo-EFIxTCT.ipynb
@@ -317,8 +317,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/03y1_Multi-Mission-Intro.ipynb
+++ b/notebooks/03y1_Multi-Mission-Intro.ipynb
@@ -275,11 +275,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -289,8 +284,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/03z1_External-Data.ipynb
+++ b/notebooks/03z1_External-Data.ipynb
@@ -140,11 +140,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -154,8 +149,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/04a1_Geomag-Models-VirES.ipynb
+++ b/notebooks/04a1_Geomag-Models-VirES.ipynb
@@ -394,11 +394,6 @@
   "execution": {
    "timeout": 1200
   },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -408,8 +403,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/04b1_Geomag-Models-eoxmagmod.ipynb
+++ b/notebooks/04b1_Geomag-Models-eoxmagmod.ipynb
@@ -281,11 +281,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -295,8 +290,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/04c1_Geomag-Ground-Data-FTP.ipynb
+++ b/notebooks/04c1_Geomag-Ground-Data-FTP.ipynb
@@ -1434,11 +1434,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -1448,8 +1443,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/04c2_Geomag-Ground-Data-VirES.ipynb
+++ b/notebooks/04c2_Geomag-Ground-Data-VirES.ipynb
@@ -365,11 +365,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -379,8 +374,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/05a1_Polar-Region-Plots.ipynb
+++ b/notebooks/05a1_Polar-Region-Plots.ipynb
@@ -556,11 +556,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -570,8 +565,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/05b1_Solar-Wind-to-Ground.ipynb
+++ b/notebooks/05b1_Solar-Wind-to-Ground.ipynb
@@ -576,11 +576,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -590,8 +585,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Clear kernelspec from notebook metadata - this avoids problems where the notebook author has a differently-named kernel attached to the notebook from that which is used in the VRE.
- Add pre-commit check for this in the CI
- Add manual triggers to the workflows. The runnability of the notebooks is still flakey (e.g. external hapi server not responding) so it's useful to re-run them later.
- Currently the staging workflow runs `pytest --nbmake` to execute notebooks then `jupyter-book` to display them (advantages: speeds up build by running 2 in parallel; errors in the code still get displayed in the jupyter-book website for debugging).