### PR TITLE
Fix deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -66,7 +66,7 @@ jobs:
           deploy-message: "Deploy from GitHub Actions (staging)"
           github-deployment-environment: staging
           github-deployment-description: "jupyter-book built from staging"
-          alias: preview-staging-${{ github.sha }}
+          alias: preview-staging
           enable-pull-request-comment: true
           enable-commit-comment: true
           overwrites-pull-request-comment: true

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -27,7 +27,7 @@ jobs:
           echo ${{ secrets.EOX_REGISTRY_PASSWORD }} | docker login -u ${{ secrets.EOX_REGISTRY_USER }} --password-stdin registry.gitlab.eox.at
           docker pull ${{ env.DOCKER_IMAGE }}
       - uses: actions/checkout@v2
-      - name: Execute notebooks
+      - name: Execute notebooks using nbmake
         run: |
           docker run -v $GITHUB_WORKSPACE:/home/jovyan -u root \
             -e VIRES_TOKEN=${{ secrets.VIRES_TOKEN }} \
@@ -66,9 +66,9 @@ jobs:
           deploy-message: "Deploy from GitHub Actions (staging)"
           github-deployment-environment: staging
           github-deployment-description: "jupyter-book built from staging"
-          alias: preview-staging-${{ github.event.number }}
+          alias: preview-staging
           enable-pull-request-comment: true
-          enable-commit-comment: false
+          enable-commit-comment: true
           overwrites-pull-request-comment: true
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v3.0
+    - uses: pre-commit/action@v3.0.0
       with:
         extra_args: --hook-stage manual --all-files
   book:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -66,7 +66,7 @@ jobs:
           deploy-message: "Deploy from GitHub Actions (staging)"
           github-deployment-environment: staging
           github-deployment-description: "jupyter-book built from staging"
-          alias: preview-staging
+          alias: preview-staging-${{ github.sha }}
           enable-pull-request-comment: true
           enable-commit-comment: true
           overwrites-pull-request-comment: true

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.3
+    - uses: pre-commit/action@v3.0
       with:
         extra_args: --hook-stage manual --all-files
   book:
@@ -53,7 +53,7 @@ jobs:
           docker run -v $GITHUB_WORKSPACE:/home/jovyan -u root ${{ env.DOCKER_IMAGE }} \
             bash -c \
               '
-              pip install jupyter-book==0.12.1 && \
+              pip install jupyter-book==0.13.1 && \
               jupyter-book build --config _config-testing.yml .
               '
       - name: Deploy preview to Netlify

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -18,6 +18,7 @@ jobs:
       with:
         extra_args: --hook-stage manual --all-files
   book:
+    needs: pre-commit
     name: Build Jupyter Book (Staging)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,17 @@ env:
   DOCKER_IMAGE: 'registry.gitlab.eox.at/esa/vires_vre_ops/vre-swarm-notebook:0.10.5'
 
 jobs:
-  run:
+  pre-commit:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.3
+      with:
+        extra_args: --hook-stage manual --all-files
+  book:
+    needs: pre-commit
     name: Build Jupyter Book (Production)
     runs-on: ubuntu-latest
     steps:
@@ -39,9 +49,9 @@ jobs:
           deploy-message: "Deploy from GitHub Actions (master)"
           github-deployment-environment: production-preview
           github-deployment-description: "jupyter-book production preview"
-          alias: preview-master-${{ github.event.number }}
+          alias: preview-master-${{ github.sha }}
           enable-pull-request-comment: true
-          enable-commit-comment: false
+          enable-commit-comment: true
           overwrites-pull-request-comment: true
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v3.0
+    - uses: pre-commit/action@v3.0.0
       with:
         extra_args: --hook-stage manual --all-files
   book:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
           deploy-message: "Deploy from GitHub Actions (master)"
           github-deployment-environment: production-preview
           github-deployment-description: "jupyter-book production preview"
-          alias: preview-master-${{ github.sha }}
+          alias: preview-master
           enable-pull-request-comment: true
           enable-commit-comment: true
           overwrites-pull-request-comment: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.3
+    - uses: pre-commit/action@v3.0
       with:
         extra_args: --hook-stage manual --all-files
   book:
@@ -36,7 +36,7 @@ jobs:
               '
               viresclient set_token https://vires.services/ows $VIRES_TOKEN && \
               viresclient set_default_server https://vires.services/ows && \
-              pip install jupyter-book==0.12.1 && \
+              pip install jupyter-book==0.13.1 && \
               jupyter-book build --config _config.yml .
               '
       - name: Deploy preview to Netlify

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: nbstripout
         args: ["--extra-keys", "metadata.language_info.version"]
- - repo: https://github.com/mwouts/jupytext
+  - repo: https://github.com/mwouts/jupytext
     rev: v1.13.7
     hooks:
     - id: jupytext

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.5.0
+    rev: 0.6.0
     hooks:
       - id: nbstripout
         args: [
@@ -10,7 +10,7 @@ repos:
           "metadata.vscode",
         ]
   - repo: https://github.com/mwouts/jupytext
-    rev: v1.13.7
+    rev: v1.14.1
     hooks:
     - id: jupytext
       args: [--from, ipynb, --to, ipynb, --update-metadata, '{"kernelspec": {"display_name": "Python 3 (ipykernel)", "language": "python", "name": "python3"}}']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,9 @@ repos:
     rev: 0.5.0
     hooks:
       - id: nbstripout
-        args: ["--extra-keys", "metadata.kernelspec metadata.language_info.version"]
+        args: ["--extra-keys", "metadata.language_info.version"]
+ - repo: https://github.com/mwouts/jupytext
+    rev: v1.13.7
+    hooks:
+    - id: jupytext
+      args: [--sync, --from, ipynb, --to, ipynb, --update-metadata, '{"kernelspec": {"display_name": "Python 3 (ipykernel)", "language": "python", "name": "python3"}}']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,14 @@ repos:
     rev: 0.5.0
     hooks:
       - id: nbstripout
-        args: ["--extra-keys", "metadata.language_info.version"]
+        args: [
+          "--extra-keys",
+          "metadata.language_info.version",
+          "metadata.kernelspec",
+          "metadata.vscode",
+        ]
   - repo: https://github.com/mwouts/jupytext
     rev: v1.13.7
     hooks:
     - id: jupytext
-      args: [--sync, --from, ipynb, --to, ipynb, --update-metadata, '{"kernelspec": {"display_name": "Python 3 (ipykernel)", "language": "python", "name": "python3"}}']
+      args: [--from, ipynb, --to, ipynb, --update-metadata, '{"kernelspec": {"display_name": "Python 3 (ipykernel)", "language": "python", "name": "python3"}}']

--- a/dashboards/0000_concept_demo.ipynb
+++ b/dashboards/0000_concept_demo.ipynb
@@ -182,6 +182,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/dashboards/00_Product-Availability.ipynb
+++ b/dashboards/00_Product-Availability.ipynb
@@ -358,6 +358,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/dashboards/02_GVO-Geomagnetic-Virtual-Observatories.ipynb
+++ b/dashboards/02_GVO-Geomagnetic-Virtual-Observatories.ipynb
@@ -618,6 +618,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/dashboards/04_Conjunctions.ipynb
+++ b/dashboards/04_Conjunctions.ipynb
@@ -295,6 +295,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/01a__Intro-Jupyter-Python.ipynb
+++ b/notebooks/01a__Intro-Jupyter-Python.ipynb
@@ -869,6 +869,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/01b1_Pandas-and-Plots.ipynb
+++ b/notebooks/01b1_Pandas-and-Plots.ipynb
@@ -552,6 +552,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/02a__Intro-Swarm-viresclient.ipynb
+++ b/notebooks/02a__Intro-Swarm-viresclient.ipynb
@@ -316,6 +316,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/02b__viresclient-Available-Data.ipynb
+++ b/notebooks/02b__viresclient-Available-Data.ipynb
@@ -382,6 +382,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/02c__viresclient-API.ipynb
+++ b/notebooks/02c__viresclient-API.ipynb
@@ -3366,6 +3366,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/02d__viresclient-Large-Data.ipynb
+++ b/notebooks/02d__viresclient-Large-Data.ipynb
@@ -307,6 +307,11 @@
   "execution": {
    "timeout": 1200
   },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/02e1_Conjunction-Interface.ipynb
+++ b/notebooks/02e1_Conjunction-Interface.ipynb
@@ -200,6 +200,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/02h1_HAPI.ipynb
+++ b/notebooks/02h1_HAPI.ipynb
@@ -124,6 +124,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/02z1__Template-Basic.ipynb
+++ b/notebooks/02z1__Template-Basic.ipynb
@@ -164,6 +164,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/03a1_Demo-MAGx_LR_1B.ipynb
+++ b/notebooks/03a1_Demo-MAGx_LR_1B.ipynb
@@ -444,6 +444,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/03a2_Demo-MAGx_HR_1B.ipynb
+++ b/notebooks/03a2_Demo-MAGx_HR_1B.ipynb
@@ -167,6 +167,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/03b__Demo-EFIx_LP_1B.ipynb
+++ b/notebooks/03b__Demo-EFIx_LP_1B.ipynb
@@ -180,6 +180,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/03c__Demo-IPDxIRR_2F.ipynb
+++ b/notebooks/03c__Demo-IPDxIRR_2F.ipynb
@@ -207,6 +207,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/03d__Demo-TECxTMS_2F.ipynb
+++ b/notebooks/03d__Demo-TECxTMS_2F.ipynb
@@ -164,6 +164,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/03e1_Demo-FACxTMS_2F.ipynb
+++ b/notebooks/03e1_Demo-FACxTMS_2F.ipynb
@@ -299,6 +299,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/03e2_Demo-FAC_TMS_2F.ipynb
+++ b/notebooks/03e2_Demo-FAC_TMS_2F.ipynb
@@ -507,6 +507,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/03f__Demo-EEFxTMS_2F.ipynb
+++ b/notebooks/03f__Demo-EEFxTMS_2F.ipynb
@@ -182,6 +182,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/03g__Demo-IBIxTMS_2F.ipynb
+++ b/notebooks/03g__Demo-IBIxTMS_2F.ipynb
@@ -131,6 +131,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/03h1_Demo-AEBS-AEJxLPL.ipynb
+++ b/notebooks/03h1_Demo-AEBS-AEJxLPL.ipynb
@@ -609,6 +609,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/03h2_Demo-AEBS-AEJxLPS.ipynb
+++ b/notebooks/03h2_Demo-AEBS-AEJxLPS.ipynb
@@ -442,6 +442,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/03h3_Demo-AEBS-AOBxFAC.ipynb
+++ b/notebooks/03h3_Demo-AEBS-AOBxFAC.ipynb
@@ -244,6 +244,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/03i1_Demo-VOBS.ipynb
+++ b/notebooks/03i1_Demo-VOBS.ipynb
@@ -613,6 +613,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/03j1_Demo-PRISM-MITx.ipynb
+++ b/notebooks/03j1_Demo-PRISM-MITx.ipynb
@@ -287,6 +287,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/03k1_Demo-EFIxTIE.ipynb
+++ b/notebooks/03k1_Demo-EFIxTIE.ipynb
@@ -275,6 +275,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/03k2_Demo-EFIxTCT.ipynb
+++ b/notebooks/03k2_Demo-EFIxTCT.ipynb
@@ -309,6 +309,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/03y1_Multi-Mission-Intro.ipynb
+++ b/notebooks/03y1_Multi-Mission-Intro.ipynb
@@ -275,6 +275,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/03z1_External-Data.ipynb
+++ b/notebooks/03z1_External-Data.ipynb
@@ -140,6 +140,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/04a1_Geomag-Models-VirES.ipynb
+++ b/notebooks/04a1_Geomag-Models-VirES.ipynb
@@ -394,6 +394,11 @@
   "execution": {
    "timeout": 1200
   },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/04b1_Geomag-Models-eoxmagmod.ipynb
+++ b/notebooks/04b1_Geomag-Models-eoxmagmod.ipynb
@@ -281,6 +281,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/04c1_Geomag-Ground-Data-FTP.ipynb
+++ b/notebooks/04c1_Geomag-Ground-Data-FTP.ipynb
@@ -1434,6 +1434,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/04c2_Geomag-Ground-Data-VirES.ipynb
+++ b/notebooks/04c2_Geomag-Ground-Data-VirES.ipynb
@@ -368,6 +368,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/05a1_Polar-Region-Plots.ipynb
+++ b/notebooks/05a1_Polar-Region-Plots.ipynb
@@ -556,6 +556,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/05b1_Solar-Wind-to-Ground.ipynb
+++ b/notebooks/05b1_Solar-Wind-to-Ground.ipynb
@@ -588,6 +588,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",


### PR DESCRIPTION
- fixes broken rocket button on jupyter-book build by reintroducing the kernelspec to notebooks
- two pre-commit hooks work together:
  - nbstripout removes various metadata (helpful to keep commits clean of environment-specific additions)
  - jupytext writes back the minimally-required metadata:
    `{"kernelspec": {"display_name": "Python 3 (ipykernel)", "language": "python", "name": "python3"}}`