### PR TITLE
Use the header/announcement to add links to other docs

### DIFF
--- a/_config-ci-master.yml
+++ b/_config-ci-master.yml
@@ -30,6 +30,41 @@ html:
   home_page_in_navbar       : true
   comments:
     hypothesis              : true
+  announcement: '
+    <div class="custom-header-container">
+        <div>
+            <a href="https://viresclient.readthedocs.io" target="_blank" class="link">viresclient</a>
+            <a href="https://vires.services" target="_blank" class="link">VirES for Swarm</a>
+            <a href="https://vre.vires.services" target="_blank" class="link">Swarm JupyterHub</a>
+            <a href="" class="link-selected">Swarm Notebooks</a>
+            <a href="https://swarmpal.readthedocs.io" target="_blank" class="link">SwarmPAL</a>
+        </div>
+    </div>
+
+    <style>
+        .custom-header-container {}
+
+        .custom-header-container .link {
+            margin: 0 10px;
+            padding: 5px 10px;
+            text-decoration: none;
+            color: white;
+        }
+
+        .custom-header-container .link:hover {
+            color: #1e90ff !important;
+        }
+
+        .custom-header-container .link-selected {
+            margin: 0 10px;
+            padding: 5px 10px;
+            text-decoration: none;
+            background-color: #ccc;
+            color: black;
+            border-radius: 5px;
+        }
+    </style>
+  '
 
 # See https://jupyterbook.org/content/content-blocks.html
 parse:

--- a/_config-ci-master.yml
+++ b/_config-ci-master.yml
@@ -33,11 +33,12 @@ html:
   announcement: '
     <div class="custom-header-container">
         <div>
-            <a href="https://viresclient.readthedocs.io" target="_blank" class="link">viresclient</a>
-            <a href="https://vires.services" target="_blank" class="link">VirES for Swarm</a>
-            <a href="https://vre.vires.services" target="_blank" class="link">Swarm JupyterHub</a>
+            <a href="https://viresclient.readthedocs.io" class="link">viresclient</a>
+            
             <a href="" class="link-selected">Swarm Notebooks</a>
-            <a href="https://swarmpal.readthedocs.io" target="_blank" class="link">SwarmPAL</a>
+            <a href="https://swarmpal.readthedocs.io" class="link">SwarmPAL</a>
+            <a href="https://vires.services" target="_blank" class="link">VirES for Swarm ↗</a>
+            <a href="https://vre.vires.services" target="_blank" class="link">Swarm JupyterHub ↗</a>
         </div>
     </div>
 

--- a/_config-ci-staging.yml
+++ b/_config-ci-staging.yml
@@ -30,6 +30,41 @@ html:
   home_page_in_navbar       : true
   comments:
     hypothesis              : true
+  announcement: '
+    <div class="custom-header-container">
+        <div>
+            <a href="https://viresclient.readthedocs.io" target="_blank" class="link">viresclient</a>
+            <a href="https://vires.services" target="_blank" class="link">VirES for Swarm</a>
+            <a href="https://vre.vires.services" target="_blank" class="link">Swarm JupyterHub</a>
+            <a href="" class="link-selected">Swarm Notebooks</a>
+            <a href="https://swarmpal.readthedocs.io" target="_blank" class="link">SwarmPAL</a>
+        </div>
+    </div>
+
+    <style>
+        .custom-header-container {}
+
+        .custom-header-container .link {
+            margin: 0 10px;
+            padding: 5px 10px;
+            text-decoration: none;
+            color: white;
+        }
+
+        .custom-header-container .link:hover {
+            color: #1e90ff !important;
+        }
+
+        .custom-header-container .link-selected {
+            margin: 0 10px;
+            padding: 5px 10px;
+            text-decoration: none;
+            background-color: #ccc;
+            color: black;
+            border-radius: 5px;
+        }
+    </style>
+  '
 
 # See https://jupyterbook.org/content/content-blocks.html
 parse:

--- a/_config-ci-staging.yml
+++ b/_config-ci-staging.yml
@@ -33,11 +33,12 @@ html:
   announcement: '
     <div class="custom-header-container">
         <div>
-            <a href="https://viresclient.readthedocs.io" target="_blank" class="link">viresclient</a>
-            <a href="https://vires.services" target="_blank" class="link">VirES for Swarm</a>
-            <a href="https://vre.vires.services" target="_blank" class="link">Swarm JupyterHub</a>
+            <a href="https://viresclient.readthedocs.io" class="link">viresclient</a>
+            
             <a href="" class="link-selected">Swarm Notebooks</a>
-            <a href="https://swarmpal.readthedocs.io" target="_blank" class="link">SwarmPAL</a>
+            <a href="https://swarmpal.readthedocs.io" class="link">SwarmPAL</a>
+            <a href="https://vires.services" target="_blank" class="link">VirES for Swarm ↗</a>
+            <a href="https://vre.vires.services" target="_blank" class="link">Swarm JupyterHub ↗</a>
         </div>
     </div>
 


### PR DESCRIPTION
This will help people find the related pages (viresclient & swarmpal documentation, etc). Similar headers will be added to the viresclient and SwarmPAL documentation so people can move between them easily